### PR TITLE
Make efmt selectable as formatter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,8 @@ import child_process = require("child_process");
 import { workspace, TextDocument, TextEdit, window } from "vscode";
 import path = require("path");
 
-type FormatterName = "rebar3_format" | "steamroller" | "erlfmt";
-type FormatterCommand = "format" | "steamroll" | "fmt";
+type FormatterName = "rebar3_format" | "steamroller" | "erlfmt" | "rebar3_efmt";
+type FormatterCommand = "format" | "steamroll" | "fmt" | "efmt";
 
 function format(
   filePath: string,
@@ -76,6 +76,8 @@ function formatterArgs(outputChannel: vscode.OutputChannel): string[] {
       return [formatterCommand(formatter), "-f"];
     case "erlfmt":
       return [formatterCommand(formatter), "-w"];
+    case "rebar3_efmt":
+      return [formatterCommand(formatter), "-w"];
     default:
       throw new Error(
         `Error while reading Erlang formatter configuration: ${formatter}`
@@ -108,6 +110,8 @@ function formatterName(formatterCommand: FormatterCommand): FormatterName {
       return "steamroller";
     case "fmt":
       return "erlfmt";
+    case "efmt":
+      return "rebar3_efmt";
     default:
       throw new Error(
         `Could not find the formatter name for ${formatterCommand}`
@@ -123,6 +127,8 @@ function formatterCommand(formatterName: FormatterName): FormatterCommand {
       return "steamroll";
     case "erlfmt":
       return "fmt";
+    case "rebar3_efmt":
+      return "efmt";
     default:
       throw new Error(
         `Could not find the formatter command for ${formatterName}`


### PR DESCRIPTION
[`efmt`](https://github.com/sile/efmt) can now be selected as a formatter.

The operation was checked in the following environment.

- PC
  - macOS Monterey Version 12.3
- Visual Studio Code
  - Version: 1.76.2
  - Commit: ee2b180d582a7f601fa6ecfdad8d9fd269ab1884
  - Date: 2023-03-14T17:54:09.061Z
  - Electron: 19.1.11
  - Chromium: 102.0.5005.196
  - Node.js: 16.14.2
  - V8: 10.2.154.26-electron.0
  - OS: Darwin x64 21.4.0
  - Sandboxed: Yes
- Erlang / Rebar3
  - rebar 3.20.0 on Erlang/OTP 25 Erts 13.1.3